### PR TITLE
Handle more error cases

### DIFF
--- a/sopel_boorus/gelbooru/plugin.py
+++ b/sopel_boorus/gelbooru/plugin.py
@@ -88,9 +88,12 @@ def search_tags(tags: str) -> dict:
 def refresh_cache(cache: QueryCache, query: str):
     """Fetch and store a batch of results for ``query`` in the ``cache``."""
     data = search_tags(query)
-    posts = data['post']
-    new_items: list[GelbooruPost] = []
+    posts = data.get('post', [])
 
+    if not posts:
+        return
+
+    new_items: list[GelbooruPost] = []
     for post in posts:
         # no need to shuffle anything here, since `search_tags()` already adds
         # `sort:random` to the search query; gelbooru.com shuffles for us

--- a/sopel_boorus/util.py
+++ b/sopel_boorus/util.py
@@ -39,10 +39,12 @@ def get_json(url: str, params: dict[str, Any] | None = None) -> dict:
         raise errors.ServerError("Couldn't connect to server.")
     except requests.exceptions.ReadTimeout:
         raise errors.ServerError("Server took too long to send data.")
+    if r.status_code == 422:
+        raise errors.APIError("You probably used too many tags. (HTTP 422)")
     try:
         r.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        raise errors.APIError("HTTP error: " + str(e))
+        raise errors.APIError("HTTP error " + str(e.response.status_code))
     try:
         data = r.json()
     except ValueError:


### PR DESCRIPTION
The encapsulation on this is not the best—AFAIK HTTP 422 for too many tags is a Danbooru thing and Gelbooru won't do that—but I don't want to rework how `util.get_json()` works just now.

As stated in the root commit's message, a lot of the plugin's meta-structure stuff probably needs to be reworked for better abstraction. The goal here is to patch a few "Unexpected" exceptions that should be handled gracefully just so the plugins are more stable, while I think about a redesign.