### PR TITLE
Fix/streamline rating display logic

### DIFF
--- a/sopel_boorus/danbooru/plugin.py
+++ b/sopel_boorus/danbooru/plugin.py
@@ -39,18 +39,6 @@ def shutdown(bot):
         pass
 
 
-def _colorize_rating(rating: str) -> str:
-    if rating == 'explicit':
-        return "\x02\x0304NSFW\x03\x02"
-    elif rating == 'sensitive':
-        return "\x02\x0307Sensitive\x03\x02"
-    elif rating == 'questionable':
-        return "\x02\x0308Questionable\x03\x02"
-    elif rating == 'general':
-        return "\x02\x0309Safe\x03\x02"
-    raise RuntimeError('Unknown rating %r' % rating)
-
-
 def fetch_post(id_: int) -> dict:
     """Fetch a Danbooru post by ID.
 
@@ -90,7 +78,7 @@ def say_post(bot: SopelWrapper, post: DanbooruPost, link=True):
     bot.say(
         template.format(
             score=post.score_str,
-            rating=_colorize_rating(post.rating),
+            rating=post.display_rating,
             tags=post.tag_string,
         ),
         truncation=' […]',

--- a/sopel_boorus/danbooru/types.py
+++ b/sopel_boorus/danbooru/types.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Type
 
+from sopel.formatting import colors
+
 from ..types import AbstractBooruPost
 
 
@@ -19,6 +21,12 @@ RATING_MAP = {
     's': 'sensitive',
     'q': 'questionable',
     'e': 'explicit',
+}
+RATING_COLOR_MAP = {
+    'g': colors.LIGHT_GREEN,
+    's': colors.YELLOW,
+    'q': colors.ORANGE,
+    'e': colors.RED,
 }
 
 
@@ -63,6 +71,10 @@ class DanbooruPost(AbstractBooruPost):
     @property
     def rating(self) -> str:
         return RATING_MAP.get(self._rating)
+
+    @property
+    def rating_color(self) -> str:
+        return RATING_COLOR_MAP.get(self._rating)
 
     @property
     def tags(self) -> str:

--- a/sopel_boorus/gelbooru/plugin.py
+++ b/sopel_boorus/gelbooru/plugin.py
@@ -42,18 +42,6 @@ def shutdown(bot):
         pass
 
 
-def _colorize_rating(rating: str) -> str:
-    if rating == 'explicit':
-        return "\x02\x0304NSFW\x03\x02"
-    elif rating == 'sensitive':
-        return "\x02\x0307Sensitive\x03\x02"
-    elif rating == 'questionable':
-        return "\x02\x0308Questionable\x03\x02"
-    elif rating == 'general':
-        return "\x02\x0309Safe\x03\x02"
-    raise RuntimeError('Unknown rating %r' % rating)
-
-
 def fetch_post(id_: int) -> dict:
     """Fetch a Gelbooru post by ID.
 
@@ -105,7 +93,7 @@ def say_post(bot: SopelWrapper, post: GelbooruPost, link=True):
     bot.say(
         template.format(
             score=post.score_str,
-            rating=_colorize_rating(post.rating),
+            rating=post.display_rating,
             tags=post.tag_string,
         ),
         truncation=' […]',

--- a/sopel_boorus/gelbooru/types.py
+++ b/sopel_boorus/gelbooru/types.py
@@ -11,7 +11,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Type
 
+from sopel.formatting import colors
+
 from ..types import AbstractBooruPost
+
+
+RATING_COLOR_MAP = {
+    'general': colors.LIGHT_GREEN,
+    'sensitive': colors.YELLOW,
+    'questionable': colors.ORANGE,
+    'explicit': colors.RED,
+}
 
 
 class GelbooruPost(AbstractBooruPost):
@@ -62,6 +72,10 @@ class GelbooruPost(AbstractBooruPost):
     @property
     def rating(self) -> str:
         return self._rating
+
+    @property
+    def rating_color(self) -> str:
+        return RATING_COLOR_MAP.get(self._rating)
 
     @property
     def tags(self) -> str:

--- a/sopel_boorus/types.py
+++ b/sopel_boorus/types.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from sopel import formatting as fmt
+
 
 class AbstractBooruPost:
     """Interface definition of a booru post.
@@ -49,6 +51,20 @@ class AbstractBooruPost:
         their meanings are booru-dependent.
         """
         raise NotImplementedError
+
+    @property
+    def rating_color(self) -> str:
+        """The IRC color to use for this post's content rating.
+
+        Simplest way to do this is to map the internal rating value to a member
+        of :class:`sopel.formatting.colors`.
+        """
+        raise NotImplementedError
+
+    @property
+    def display_rating(self) -> str:
+        """This post's rating, formatted as it should be for IRC output."""
+        return fmt.bold(fmt.color(self.rating.title(), self.rating_color))
 
     @property
     def tags(self) -> list[str]:


### PR DESCRIPTION
Swaps the colors assigned to "Questionable" (now orange) and "Sensitive" (now yellow), reflecting that `q` posts are lewder than `s` posts on both Gelbooru and Danbooru.

Shoves more rating-display logic into the `AbstractBooruPost` tree. Subtypes must define color mappings for each rating on the source site, and the superclass provides a default formatted representation (bold + color with title-case).