### PR TITLE
types: unescape HTML entities in tags for display

### DIFF
--- a/sopel_boorus/types.py
+++ b/sopel_boorus/types.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from html import unescape
+
 
 class AbstractBooruPost:
     """Interface definition of a booru post.
@@ -58,7 +60,7 @@ class AbstractBooruPost:
     @property
     def tag_string(self) -> str:
         """The post's tags, as a string for display."""
-        return ' '.join(self.tags)
+        return unescape(' '.join(self.tags))
 
     @property
     def date(self) -> datetime:


### PR DESCRIPTION
Doing this in `tag_string()` shares the implementation across all current and future supported boorus. Booru subclasses are responsible for storing their tags as an actual `list`, but there's no need to make them all reinvent the `html.unescape()` wheel.