### PR TITLE
danbooru: make URL matching slightly less strict

### DIFF
--- a/sopel_boorus/danbooru/plugin.py
+++ b/sopel_boorus/danbooru/plugin.py
@@ -124,7 +124,7 @@ def danbooru(bot, trigger):
     say_post(bot, post, link=True)
 
 
-@plugin.url(r'https?://danbooru\.donmai\.us/posts/(\d+)/?(?:\?.*|$)')
+@plugin.url(r'https?://danbooru\.donmai\.us/posts/(\d+)/?(?:[?#].*|$)')
 @plugin.output_prefix(OUTPUT_PREFIX)
 def danbooru_url(bot, trigger):
     """Look up a Danbooru post when linked in chat."""

--- a/sopel_boorus/danbooru/plugin.py
+++ b/sopel_boorus/danbooru/plugin.py
@@ -124,7 +124,7 @@ def danbooru(bot, trigger):
     say_post(bot, post, link=True)
 
 
-@plugin.url(r'https?://danbooru\.donmai\.us/posts/(\d+)/?$')
+@plugin.url(r'https?://danbooru\.donmai\.us/posts/(\d+)/?(?:\?.*|$)')
 @plugin.output_prefix(OUTPUT_PREFIX)
 def danbooru_url(bot, trigger):
     """Look up a Danbooru post when linked in chat."""


### PR DESCRIPTION
Overdid it in the previous patch…

Redux of #8, partially. Closes #6 again. Unless this needs to allow `#` too…?