### PR TITLE
Fix danbooru search function not actually returning its result

### DIFF
--- a/sopel_boorus/danbooru/plugin.py
+++ b/sopel_boorus/danbooru/plugin.py
@@ -64,12 +64,17 @@ def search_tags(tags: str) -> dict:
             "Danbooru API error: %s (%s)", data['error'], data['message'])
         raise errors.APIError(data['message'])
 
+    return data
+
 
 def refresh_cache(cache: QueryCache, query: str):
     """Fetch and store a batch of results for ``query`` in the ``cache``."""
     posts = search_tags(query)
-    new_items: list[DanbooruPost] = []
 
+    if not posts:
+        return
+
+    new_items: list[DanbooruPost] = []
     for post in posts:
         # no need to shuffle anything here, since `search_tags()` already adds
         # `random:10` to the search query; danbooru.donmai.us shuffles for us


### PR DESCRIPTION
Broke this when adding the error handler (#1). I'm smart!

It's funny, I thought I'd found a bug with what happens if there are no search results, but it was actually just totally not working because my past self was a derp who didn't test thoroughly enough. (I don't use Danbooru because of their absurd tag limits.)