### PR TITLE
Slightly cleaner `search_tags()` abstraction

### DIFF
--- a/sopel_boorus/danbooru/plugin.py
+++ b/sopel_boorus/danbooru/plugin.py
@@ -48,7 +48,7 @@ def fetch_post(id_: int) -> dict:
     return get_json(API_POST_TMPL.format(id=id_))
 
 
-def search_tags(tags: str) -> dict:
+def search_tags(tags: str) -> list:
     """Search for random posts matching ``tags``, after normalization.
 
     Exceptions from :func:`..util.get_json` can bubble up.
@@ -60,10 +60,15 @@ def search_tags(tags: str) -> dict:
     })
 
     if 'error' in data:
+        # Bit weird but should be safe. The expected list of post dicts will
+        # never contain the literal string 'error', but for errors the API
+        # returns a dict with 'error' and 'message' keys instead of a list.
         LOGGER.info(
             "Danbooru API error: %s (%s)", data['error'], data['message'])
         raise errors.APIError(data['message'])
 
+    # thankfully, if there was no error, Danbooru just directly returns a list
+    # (which is simply empty if there are no results)
     return data
 
 

--- a/sopel_boorus/gelbooru/plugin.py
+++ b/sopel_boorus/gelbooru/plugin.py
@@ -56,14 +56,14 @@ def fetch_post(id_: int) -> dict:
     })['post'][0]
 
 
-def search_tags(tags: str) -> dict:
+def search_tags(tags: str) -> list:
     """Search for random posts matching ``tags``, after normalization.
 
     Exceptions from :func:`..util.get_json` can bubble up.
     """
     tags += ' sort:random'
 
-    return get_json(API_BASE, params={
+    data = get_json(API_BASE, params={
         'page': 'dapi',
         's': 'post',
         'q': 'index',
@@ -72,11 +72,13 @@ def search_tags(tags: str) -> dict:
         'json': 1,
     })
 
+    # gotta love Gelbooru jank; Danbooru just returns a list, no dict wrapper
+    return data.get('post', [])
+
 
 def refresh_cache(cache: QueryCache, query: str):
     """Fetch and store a batch of results for ``query`` in the ``cache``."""
-    data = search_tags(query)
-    posts = data.get('post', [])
+    posts = search_tags(query)
 
     if not posts:
         return

--- a/sopel_boorus/util.py
+++ b/sopel_boorus/util.py
@@ -21,7 +21,7 @@ from . import errors
 LOGGER = get_logger('boorus.util')
 
 
-def get_json(url: str, params: dict[str, Any] | None = None) -> dict:
+def get_json(url: str, params: dict[str, Any] | None = None) -> list | dict:
     """Fetch data from a JSON endpoint and return the parsed data.
 
     This function only deals with GET requests, but its advantage is in


### PR DESCRIPTION
Danbooru returns a list directly, and Gelbooru results are easy to turn into a list within the search function.

Eventually this *might* let me do some code deduplication of stuff like `refresh_cache()` etc., but I'm not thinking too hard about it now. It just annoyed me that the type hints were sometimes wrong and that two functions doing "identical" work returned different actual data types.